### PR TITLE
Optimize authorization removal

### DIFF
--- a/test/AccessManagement.test.js
+++ b/test/AccessManagement.test.js
@@ -165,6 +165,15 @@ describe('AccessManagement', function () {
         authList.push(await accessManagement.getAssetAuthorizationAtIndex(testAssetKey, i));
       }
       expect(authList).to.have.members([user1.address, user2.address, user3.address]);
+
+      await accessManagement.removeAuthorization(testAssetKey, user2.address);
+      const newCount = await accessManagement.getAssetAuthorizationCount(testAssetKey);
+      expect(newCount).to.equal(2);
+      const newAuthList = [];
+      for (let i = 0; i < newCount; i++) {
+        newAuthList.push(await accessManagement.getAssetAuthorizationAtIndex(testAssetKey, i));
+      }
+      expect(newAuthList).to.have.members([user1.address, user3.address]);
     });
   });
 


### PR DESCRIPTION
## Summary
- track authorization array indices in `Asset` struct
- swap and pop on authorization removal to keep array compact
- expand authorization listing test to verify removals

## Testing
- `npm test` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_68961383aa90832c8f292ed13a5b09b8